### PR TITLE
Updates to linknotifier

### DIFF
--- a/plugins/linknotifier/main.go
+++ b/plugins/linknotifier/main.go
@@ -93,10 +93,10 @@ func (p SortedProxyInfo) Swap(i, j int) {
 }
 func (p SortedProxyInfo) Less(i, j int) bool {
     // sort by LocalPort then by ClientPrefix
-    if s[i].LocalPort != s[j].LocalPort {
-        return s[i].ClientPrefix < s[j].ClientPrefix
+    if p[i].LocalPort == p[j].LocalPort {
+        return p[i].ClientPrefix < p[j].ClientPrefix
     } else {        
-        return s[i].LocalPort < s[j].LocalPort
+        return p[i].LocalPort < p[j].LocalPort
     }
 }
 
@@ -384,7 +384,6 @@ func notifier_main() {
                 fmt.Printf("In notifier_main(): at least %d sec since last modification .. doing notification now\n", FRPS_LINK_NOTIFIER_DELAY_SEC)
 
                 mutex.RLock()
-
                 // first check for validity of each connection and flag unresponsive ones
                 should_notify := false
                 num_active := 0
@@ -454,12 +453,12 @@ func notifier_main() {
                                 }
                             }
                             // sort both active and inactive lists
-                            for _, proxy_list := range display_proxy_list.Active {
-                                sort.Sort(SortedProxyInfo(proxy_list))
+                            for k, _ := range display_proxy_list.Active {
+                                sort.Sort(SortedProxyInfo(display_proxy_list.Active[k]))
                             }
                             
-                            for _, proxy_list := range display_proxy_list.Inactive {
-                                sort.Sort(SortedProxyInfo(proxy_list))
+                            for k, _ := range display_proxy_list.Inactive {
+                                sort.Sort(SortedProxyInfo(display_proxy_list.Inactive[k]))
                             }
                             
 

--- a/plugins/linknotifier/main.go
+++ b/plugins/linknotifier/main.go
@@ -17,6 +17,7 @@ import (
     "text/template"
     "net/smtp"
     "bytes"
+    "sort"
 )
 
 type Request struct {
@@ -419,7 +420,8 @@ func notifier_main() {
                 if should_notify {
 
                     var num_sent_emails int = 0
-
+                    var email_recipients []string
+                    
                     // go over each group and create a notification list
                     for email, proxy_ref_list := range gruped_proxies {
 
@@ -482,7 +484,8 @@ func notifier_main() {
                             }
 
                             num_sent_emails = num_sent_emails + 1
-
+                            email_recipients = append(email_recipients, email)
+                            
                             // mark both active and inactive connections as notified
                             for _, proxy_ref := range proxy_ref_list {
                                 if proxy_ref.Active {
@@ -507,7 +510,7 @@ func notifier_main() {
                         }
                     }
 
-                    fmt.Printf("In notifier_main(): notification email sent to %d recipient(s)\n", num_sent_emails)
+                    fmt.Printf("In notifier_main(): notification email sent to %d recipient(s): %s\n", num_sent_emails, strings.Join(email_recipients[:],", "))
 
                     // save updated links
                     saveProxyLinksJSON()


### PR DESCRIPTION
Updated linknotifier:
 - sorting proxy links by local port and by client prefix (aka host name) for better readability of URLs in the received email
 - printing recipient email addresses to log when email is sent 