### PR TITLE
Critical bug fixes in port manager and link notifier plugins

### DIFF
--- a/plugins/portmanager/main.go
+++ b/plugins/portmanager/main.go
@@ -89,16 +89,16 @@ func handler(w http.ResponseWriter, r *http.Request) {
                     fmt.Fprintf(w, "Not allowed.")
                     return
                 }
-
+                
                 if r.Content["proxy_type"] == "tcp" || r.Content["proxy_type"] == "udp" {
-
+                    
                     var key = fmt.Sprintf("%v:%v", r.Content["proxy_name"], r.Content["proxy_type"])
                     var port int = int(r.Content["remote_port"].(float64))
 
                     // Allocate or retrieve port
                     if port == 0 {
 
-                        mutex.RLock()
+                       mutex.Lock()
 
                         port, ok := ports[key]
 
@@ -120,11 +120,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
                             }
 
                             if port == 0 {
+                                fmt.Printf("[portmanager - %s] WARNING: Unable to allocate port, all available ports already taken.\n", key)
+                                
                                 o.Reject = true
                                 o.RejectReason = "All available ports already taken"
-
                             } else {
-
+                                fmt.Printf("[portmanager - %s] New client found, allocating new port: '%d'.\n", key, port)
+                                
                                 ports[key] = port
                                 savePortMapping()
 
@@ -136,7 +138,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
                             }
 
                         } else {
-
+                            fmt.Printf("[portmanager - %s] Known client ... using port %d.\n", key, port)
+                            
                             o.Reject = false
                             o.Unchange = false
                             o.Content = r.Content
@@ -144,15 +147,17 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
                         }
 
-                        mutex.RUnlock()
+                        mutex.Unlock()
 
                     } else {
                         // Verify that port is not taken
 
-                        mutex.RLock()
+                        mutex.Lock()
 
                         var found bool = false
 
+                        fmt.Printf("[portmanager - %s] New client ... allocating requested port '%d'.\n", key, port)
+                        
                         for k, v := range ports {
                             if v == port {
                                 if k == key {
@@ -161,6 +166,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
                                 } else {
                                     o.Reject = true
                                     o.RejectReason = "Port already taken by another proxy"
+                                    fmt.Printf("[portmanager - %s] WARNING: Cannot allocate, port already taken by another client!.\n", key, port)
                                 }
                                 found = true
                             }
@@ -177,10 +183,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
                             } else {
                                 o.Reject = true
                                 o.RejectReason = "Illegal port number"
+                                fmt.Printf("[portmanager - %s] WARNING: Illegal port number requested!.\n", key, port)
                             }
                         }
 
-                        mutex.RUnlock()
+                        mutex.Unlock()
 
                     }
 
@@ -205,10 +212,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 
+    mutex.Lock()
+    
     f, err := os.Open("ports.map")
 
     if !os.IsNotExist(err) {
-        var lineParser = regexp.MustCompile(`^([^\\w]+) ([0-9]+)$`)
+
+        fmt.Printf("[portmanager]: Reading cached port mapping in 'ports.map'\n")
+        var lineParser = regexp.MustCompile(`^(\S+) ([0-9]+)$`)
 
         s := bufio.NewScanner(f)
         for s.Scan() {
@@ -221,16 +232,25 @@ func main() {
                 port := int(port64)
 
                 if port >= portMin && port <= portMax {
+                    fmt.Printf("[portmanager]: Found port %d for %s\n", port, string(matches[1]))
                     ports[string(matches[1])] = int(port)
+                } else {
+                    fmt.Printf("[portmanager]: Found port %d for %s BUT DOES NOT MATCH LIMITS %d <= port <= %d.\n", port, string(matches[1]), portMin, portMax)
                 }
 
+            } else {
+                fmt.Printf("[portmanager]: Line does ot contain three parts: '%s'.\n", line)
             }
 
         }
 
-
+        fmt.Printf("[portmanager]: Done - total cached ports found: %d.\n", len(ports))
         f.Close()
+    } else {
+        fmt.Printf("[portmanager]: No cache for port mapping 'ports.map' file found\n")
     }
+    
+    mutex.Unlock()
 
     http.HandleFunc("/", handler)
     http.ListenAndServe(fmt.Sprintf(":%d", getEnvInt("PLUGIN_PORT", 9001)), nil)

--- a/start_runit
+++ b/start_runit
@@ -22,9 +22,9 @@ do
     fi
 done
 if [ $# -eq 0 ]; then
-    exec /sbin/runsvdir -P /etc/service
+    exec /usr/sbin/runsvdir -P /etc/service
 fi
-/sbin/runsvdir -P /etc/service &
+/usr/sbin/runsvdir -P /etc/service &
 
 [ "$1" == '--' ] && shift
 exec $@


### PR DESCRIPTION
Several critical bugfixes: 
 * port manager: fixed concurrency issues and correct loading of cached port maps upon staring
 * link notifier: fixed concurrency issues that crashed the plugin when too many initial connections
 * fixed path to /sbin/runsvdir (now in /usr/sbin/ instead of /sbin) in `alpine:latest` docker image
